### PR TITLE
Magda v1 Upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,6 @@ jobs:
       - run: yarn build
       - run: yarn test
 
-      - name: Setup Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.2.0
-
       - run: yarn helm-lint
 
       - name: Login to GitHub Package Repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     types: [published]
 
 env:
+  # [avoid issue when Github action upgraded from 18.04 default to 20.04](https://github.com/aws/aws-cli/issues/5262)
+  AWS_EC2_METADATA_DISABLED: true
   REPO_NAME: magda-auth-arcgis
   # Github account username (used for access github registry)
   GH_USERNAME: magdabot
@@ -30,13 +32,11 @@ jobs:
       - run: yarn build
       - run: yarn test
 
-      - name: Setup Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.2.0
-
       - name: helm-check
         run: yarn helm-lint
+
+      - name: helm-chart-version-check
+        run: yarn check-helm-chart-version deploy/${REPO_NAME}/Chart.yaml
 
       - name: Login to GitHub Package Repository
         env:
@@ -58,7 +58,6 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Release Helm Chart
         env:
           CR_TOKEN: "${{ secrets.GH_ACCESS_TOKEN }}"
@@ -72,5 +71,5 @@ jobs:
           helm package -d sync_dir ${REPO_NAME}
           helm repo index --merge "index_dir/index.yaml" sync_dir
           mv -f sync_dir/index.yaml index_dir/index.yaml
-          aws s3 sync sync_dir s3://${S3_BUCKET}/ --acl public-read
-          aws s3 cp index_dir/index.yaml s3://${S3_BUCKET}/index.yaml --acl public-read
+          aws s3 sync sync_dir s3://${S3_BUCKET}/
+          aws s3 cp index_dir/index.yaml s3://${S3_BUCKET}/index.yaml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,4 @@
+# v1.2.0
+
+- Change the way of locate session-db secret to be compatible with Magda v1 (still backwards compatible with earlier versions)
+- Avoid using .Chart.Name for image name --- it will change when use chart dependency alias

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # magda-auth-arcgis
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square)
 
 A Magda Authentication Plugin Template. You can use this as a base to build your own Magda Authentication Plugin.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,36 @@
 # magda-auth-arcgis
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
 
 A Magda Authentication Plugin Template. You can use this as a base to build your own Magda Authentication Plugin.
 
 Requires MAGDA version 0.0.58 or above.
 
 To deploy the authentication plugin with your MAGDA instance, please check [MAGDA Gateway Helm Chart Document](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/gateway/README.md).
+
+### How to Use
+1. Add the auth plugin as a [Helm Chart Dependency](https://helm.sh/docs/helm/helm_dependency/)
+```yaml
+- name: magda-auth-arcgis
+  version: 1.1.0
+  repository: https://charts.magda.io
+```
+
+2. Config the auth plugin with client Id:
+```yaml
+magda-auth-arcgis:
+  arcgisClientId: xxxxxx
+```
+
+3. Config Gatway to add the auth plugin to Gateway's plugin list (More details see [here](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/gateway/README.md))
+```yaml
+gateway:
+  authPlugins:
+  - key: "arcgis"
+    baseUrl: http://magda-auth-arcgis
+```
+
+4. Create a secret `oauth-secrets` in your deployment Magda namespace with the correct value for `arcgis-client-secret` key
 
 **Homepage:** <https://github.com/magda-io/magda-auth-arcgis>
 
@@ -37,7 +61,6 @@ Kubernetes: `>= 1.14.0-0`
 | authPluginConfig.qrCodeExtraInfoHeading | string | `""` | Only applicable & compulsory when authenticationMethod = "QR-CODE". If present, will displayed the heading underneath the QR Code image to provide extra instruction to users. e.g. how to download moile app to scan the QR Code |
 | authPluginConfig.qrCodeImgDataRequestUrl | string | `""` | Only applicable & compulsory when authenticationMethod = "QR-CODE". The url that is used by frontend client to request auth challenge data from the authentication plugin. See [Authentication Plugin Specification](https://github.com/magda-io/magda/blob/master/docs/docs/authentication-plugin-spec.md) for more details |
 | authPluginRedirectUrl | string | `nil` | the redirection url after the whole authentication process is completed. Authentication Plugins will use this value as default. The following query paramaters can be used to supply the authentication result: <ul> <li>result: (string) Compulsory. Possible value: "success" or "failure". </li> <li>errorMessage: (string) Optional. Text message to provide more information on the error to the user. </li> </ul> This field is for overriding the value set by `global.authPluginRedirectUrl`. Unless you want to have a different value only for this auth plugin, you shouldn't set this value. |
-| authPluginRedirectUrl | string | `nil` | the redirection url after the whole authentication process is completed. Authentication Plugins will use this value as default. The following query paramaters can be used to supply the authentication result: <ul> <li>result: (string) Compulsory. Possible value: "success" or "failure". </li> <li>errorMessage: (string) Optional. Text message to provide more information on the error to the user. </li> </ul> This field is for overriding the value set by `global.authPluginRedirectUrl`. Unless you want to have a different value only for this auth plugin, you shouldn't set this value. |
 | autoscaler.enabled | bool | `false` | turn on the autoscaler or not |
 | autoscaler.maxReplicas | int | `3` |  |
 | autoscaler.minReplicas | int | `1` |  |
@@ -48,7 +71,7 @@ Kubernetes: `>= 1.14.0-0`
 | defaultImage.repository | string | `"docker.io/data61"` |  |
 | esriOrgGroup | string | `""` | Optional; ArcGIS Org Group |
 | global | object | `{"authPluginRedirectUrl":"/sign-in-redirect","externalUrl":"","image":{},"rollingUpdate":{}}` | only for providing appropriate default value for helm lint |
-| image | object | `{}` |  |
+| image.name | string | `"magda-auth-arcgis"` |  |
 | replicas | int | `1` | no. of initial replicas |
 | resources.limits.cpu | string | `"50m"` |  |
 | resources.requests.cpu | string | `"10m"` |  |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -10,6 +10,30 @@ Requires MAGDA version 0.0.58 or above.
 
 To deploy the authentication plugin with your MAGDA instance, please check [MAGDA Gateway Helm Chart Document](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/gateway/README.md).
 
+### How to Use
+1. Add the auth plugin as a [Helm Chart Dependency](https://helm.sh/docs/helm/helm_dependency/)
+```yaml
+- name: magda-auth-arcgis
+  version: 1.1.0
+  repository: https://charts.magda.io
+```
+
+2. Config the auth plugin with client Id:
+```yaml
+magda-auth-arcgis:
+  arcgisClientId: xxxxxx
+```
+
+3. Config Gatway to add the auth plugin to Gateway's plugin list (More details see [here](https://github.com/magda-io/magda/blob/master/deploy/helm/internal-charts/gateway/README.md))
+```yaml
+gateway:
+  authPlugins:
+  - key: "arcgis"
+    baseUrl: http://magda-auth-arcgis
+```
+
+4. Create a secret `oauth-secrets` in your deployment Magda namespace with the correct value for `arcgis-client-secret` key
+
 {{ template "chart.homepageLine" . }}
 
 {{ template "chart.maintainersSection" . }}

--- a/deploy/magda-auth-arcgis/Chart.yaml
+++ b/deploy/magda-auth-arcgis/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: magda-auth-arcgis
-description: A Magda Authentication Plugin Template. You can use this as a base to build your own Magda Authentication Plugin.
-version: "1.0.1"
+description: A Magda Authentication Plugin Template. You can use this as a base
+  to build your own Magda Authentication Plugin.
+version: "1.2.0"
 kubeVersion: ">= 1.14.0-0"
 home: "https://github.com/magda-io/magda-auth-arcgis"
-sources: ["https://github.com/magda-io/magda-auth-arcgis"]
-
+sources: [ "https://github.com/magda-io/magda-auth-arcgis" ]

--- a/deploy/magda-auth-arcgis/templates/deployment.yaml
+++ b/deploy/magda-auth-arcgis/templates/deployment.yaml
@@ -26,7 +26,7 @@ See chart value file for details of the logic used to generate this setting valu
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository | default .Values.global.image.repository | default .Values.defaultImage.repository }}/{{ .Values.image.name | default .Chart.Name }}:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
+        image: "{{ .Values.image.repository | default .Values.global.image.repository | default .Values.defaultImage.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag | default .Values.global.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy | default .Values.defaultImage.pullPolicy }}
         command: [
             "node",
@@ -72,17 +72,29 @@ See chart value file for details of the logic used to generate this setting valu
             secretKeyRef:
               name: auth-secrets
               key: session-secret
-{{- if .Values.global.noDbAuth }}
         - name: PGUSER
           value: client
-{{- else }}
-        - name: PGUSER
-          value: client
+{{- $dbSecret := (lookup "v1" "Secret" .Release.Namespace "session-db-password") | default dict }}
+{{- $combinedBbSecret := (lookup "v1" "Secret" .Release.Namespace "combined-db-password") | default dict }}
+{{- $legacyDbSecret := (lookup "v1" "Secret" .Release.Namespace "db-passwords") | default dict }}
+{{- if $dbSecret }}
         - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
-              name: db-passwords
-              key: session-db-client
+              name: "session-db-password"
+              key: "password"
+{{- else if $combinedBbSecret }}
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "combined-db-password"
+              key: "password"
+{{- else if and ($legacyDbSecret | empty | not) (.Values.global.noDbAuth | empty) }}
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "db-passwords"
+              key: "session-db-client"
 {{- end }}
         - name: ARCGIS_CLIENT_SECRET
           valueFrom:

--- a/deploy/magda-auth-arcgis/values.yaml
+++ b/deploy/magda-auth-arcgis/values.yaml
@@ -24,17 +24,6 @@ esriOrgGroup: ""
 # </ul>
 # This field is for overriding the value set by `global.authPluginRedirectUrl`.
 # Unless you want to have a different value only for this auth plugin, you shouldn't set this value.
-authPluginRedirectUrl:
-
-# -- the redirection url after the whole authentication process is completed.
-# Authentication Plugins will use this value as default.
-# The following query paramaters can be used to supply the authentication result:
-# <ul>
-# <li>result: (string) Compulsory. Possible value: "success" or "failure". </li>
-# <li>errorMessage: (string) Optional. Text message to provide more information on the error to the user. </li>
-# </ul>
-# This field is for overriding the value set by `global.authPluginRedirectUrl`.
-# Unless you want to have a different value only for this auth plugin, you shouldn't set this value.
 authPluginRedirectUrl: 
 
 authPluginConfig:
@@ -106,9 +95,9 @@ autoscaler:
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 
-image: {}
-  # -- default docker image name 
-  # name: 
+image: 
+  name: magda-auth-arcgis
+  # -- other docker image settings could be 
   # repository: 
   # tag: 
   # pullPolicy: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magda-auth-arcgis",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "A Magda Authentication Plugin for ArcGIS / Esri system",
   "repository": "https://github.com/magda-io/magda-auth-arcgis.git",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,15 @@
     "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
     "helm-lint": "helm lint deploy/magda-auth-arcgis -f deploy/test-deploy.yaml",
     "helm-docs": "helm-docs -t ./README.md.gotmpl -o ../../README.md",
+    "update-all-charts": "helm dep up ./deploy/magda-auth-arcgis",
+    "add-all-chart-version-changes": "git ls-files -m | grep Chart.yaml | xargs git add && git ls-files -m | grep Chart.lock | xargs git add",
+    "add-all-helm-docs-changes": "yarn helm-docs && git ls-files -m | grep -i readme.md | xargs git add",
+    "version": "yarn update-helm-chart-version && yarn update-all-charts && yarn add-all-chart-version-changes && yarn add-all-helm-docs-changes",
     "retag-and-push": "retag-and-push"
   },
   "devDependencies": {
-    "@magda/docker-utils": "^0.0.58-alpha.2",
+    "@magda/ci-utils": "^1.0.2",
+    "@magda/docker-utils": "^0.0.60",
     "@types/express": "^4.0.37",
     "@types/lodash": "^4.14.162",
     "@types/mocha": "^8.0.3",
@@ -33,8 +38,8 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "@magda/auth-api-client": "^0.0.58-alpha.4",
-    "@magda/authentication-plugin-sdk": "^0.0.58-alpha.2",
+    "@magda/auth-api-client": "^0.0.60",
+    "@magda/authentication-plugin-sdk": "^0.0.60",
     "express": "^4.15.4",
     "lodash": "^4.17.20",
     "passport": "0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@magda/auth-api-client@^0.0.58-alpha.4":
-  version "0.0.58-alpha.4"
-  resolved "https://registry.yarnpkg.com/@magda/auth-api-client/-/auth-api-client-0.0.58-alpha.4.tgz#f27d8764c17bf73d6f637acf5a12c54ada956fff"
-  integrity sha512-2DcqrntnoZZVzF1uKgS2bQ5IJQWTkue8/yo1y0e6LR6hmMWcZv6r18vWD5ca2H8ud2bHE55syKMKpogSuuZ8Ew==
+"@magda/auth-api-client@^0.0.60":
+  version "0.0.60"
+  resolved "https://registry.yarnpkg.com/@magda/auth-api-client/-/auth-api-client-0.0.60.tgz#b001a3df51a8e5a6c65c65945a320047ba19c599"
+  integrity sha512-XW7pTyE47i+Uy6KPZuZz5CZfSRcmROWYZ08zH5G+raS2yadscrqFD6YWOSBNOpCG1GXbI8NEZhVuwOhmLFJjRQ==
 
-"@magda/authentication-plugin-sdk@^0.0.58-alpha.2":
-  version "0.0.58-alpha.2"
-  resolved "https://registry.yarnpkg.com/@magda/authentication-plugin-sdk/-/authentication-plugin-sdk-0.0.58-alpha.2.tgz#43f752b958f55bccf5ac49b70d9e0bd04bcbdb22"
-  integrity sha512-T/DMdVjLYTjKVLCxfJ+AzDYc/jTOtSc9OgyA3qwb5KcM97AbX7wOJ7q4jsX7ook3EX+iDGD58SK8hV9PtoESRQ==
+"@magda/authentication-plugin-sdk@^0.0.60":
+  version "0.0.60"
+  resolved "https://registry.yarnpkg.com/@magda/authentication-plugin-sdk/-/authentication-plugin-sdk-0.0.60.tgz#c99da82f658a44450c4d95ed2dd76b23a2a53d05"
+  integrity sha512-O+vMm1yQ/Uo4lF/EeuCVWTPWlPmu75FNa4nIrl73dLbU+9XW9RSIKnAOiGdRlFMTL494wCCicfBoU24ojlqpVA==
   dependencies:
     connect-pg-simple "^6.0.1"
     cookie-parser "^1.4.5"
@@ -18,12 +18,21 @@
     express-session "^1.17.1"
     lodash "^4.17.4"
     pg "^6.4.0"
-    urijs "^1.18.12"
+    urijs "^1.19.4"
 
-"@magda/docker-utils@^0.0.58-alpha.2":
-  version "0.0.58-alpha.2"
-  resolved "https://registry.yarnpkg.com/@magda/docker-utils/-/docker-utils-0.0.58-alpha.2.tgz#851ee937256405969cd478d90cdd8a38fcb6a3da"
-  integrity sha512-U30/h8qYZZ5Q1RgEPx2pyeystYnnqYx+8lcsEwpJEwgTiG4FBl2u3iTyEKYUJlWIno778X/7HiPf3ltLtxnntw==
+"@magda/ci-utils@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@magda/ci-utils/-/ci-utils-1.0.2.tgz#cf5383611a0a46f1dc7bac256e08a00f3d4c4974"
+  integrity sha512-oJ7LMNCAqG+zbwGM8RPhTepStK8HZqtF4bUWFsCqtaLnRFMKLjbM5qzWj7q/qtzLvIGAtpc45F/hoL0bszDNQQ==
+  dependencies:
+    fs-extra "^9.1.0"
+    recursive-readdir "^2.2.2"
+    yaml "^1.10.2"
+
+"@magda/docker-utils@^0.0.60":
+  version "0.0.60"
+  resolved "https://registry.yarnpkg.com/@magda/docker-utils/-/docker-utils-0.0.60.tgz#7e2002ebdb1472e3206c8e9b8f53730ac298dc33"
+  integrity sha512-jU6mYYeBPkm1cciDOiOqOlSn0Ru5BdhTkpL2qHq3nU+DMLNlgDCHD0sGyCm1iPRaDlo75igO200bFQAR1551pg==
   dependencies:
     fs-extra "^2.1.2"
     is-subdir "^1.0.2"
@@ -215,6 +224,11 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -654,6 +668,16 @@ fs-extra@^2.1.2:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
 
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -709,6 +733,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+graceful-fs@^4.2.0:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
+  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 growl@1.10.5:
   version "1.10.5"
@@ -867,6 +896,15 @@ jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
   integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -1424,6 +1462,13 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+recursive-readdir@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
+  integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
+  dependencies:
+    minimatch "3.0.4"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -1716,15 +1761,25 @@ uid2@0.0.x:
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
   integrity sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=
 
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-urijs@^1.18.12, urijs@^1.19.2:
+urijs@^1.19.2:
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.2.tgz#f9be09f00c4c5134b7cb3cf475c1dd394526265a"
   integrity sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==
+
+urijs@^1.19.4:
+  version "1.19.7"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.7.tgz#4f594e59113928fea63c00ce688fb395b1168ab9"
+  integrity sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA==
 
 util-deprecate@^1.0.1:
   version "1.0.2"
@@ -1817,6 +1872,11 @@ y18n@^5.0.2:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.4.tgz#0ab2db89dd5873b5ec4682d8e703e833373ea897"
   integrity sha512-deLOfD+RvFgrpAmSZgfGdWYE+OKyHcVHaRQ7NphG/63scpRvTHHeQMAxGGvaLVGJ+HYVcCXlzcTK0ZehFf+eHQ==
+
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
### What this PR does

- Change the way of locate session-db secret to be compatible with Magda v1 (still backwards compatible with earlier versions)
- Avoid using .Chart.Name for image name --- it will change when use chart dependency alias
- Upgrade CI script

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
